### PR TITLE
fix: ex-traP wiki のロゴが表示されていなかった

### DIFF
--- a/compose/traq/frontend-override/config.js
+++ b/compose/traq/frontend-override/config.js
@@ -17,7 +17,7 @@ const config = {
 		},
 		{
 			label: "ex-traP Wiki",
-			iconPath: "growi.svg",
+			iconPath: "crowi.svg",
 			appLink: "https://wiki.ex.trap.jp/",
 		},
 	],


### PR DESCRIPTION
<img width="433" alt="スクリーンショット 2024-03-25 23 49 57" src="https://github.com/ex-trap/infra/assets/28436261/337f83c6-4175-4a52-96e2-c05b8da94b73">


traQ-S_UI v3.18.0 に上がったタイミングで growi.svg は crowi.svg に置き換えられているので、合わせて config.js を更新

- [update traQ to 3.17.0, traq-ui to 3.19.0 · ex-trap/infra@ce04423](https://github.com/ex-trap/infra/commit/ce04423713f6fc9e3ae59a4d07de9056cb34ef07)
- [growiのアイコンをcrowiのアイコンに置換 · traPtitech/traQ_S-UI@f5c30d1](https://github.com/traPtitech/traQ_S-UI/commit/f5c30d1a44b016020a600ad8a026beda895085db)